### PR TITLE
Add underline title

### DIFF
--- a/knowledge/components/linkedNodes/LinkedNode.js
+++ b/knowledge/components/linkedNodes/LinkedNode.js
@@ -2,26 +2,28 @@ import React from "react";
 
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
-import Typography from "@mui/material/Typography";
 import List from "@mui/material/List";
 import Divider from "@mui/material/Divider";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemButton from "@mui/material/ListItemButton";
+import TypographyUnderlined from "../TypographyUnderlined";
 
 import MarkdownRender from "../Markdown/MarkdownRender";
 
 const LinkedNode = ({ header, data }) => {
   return (
     <Paper sx={{ pt: "25px" }}>
-      <Typography
-        variant="h5"
-        gutterBottom
-        marked="center"
-        align="center"
-        sx={{ fontSize: "25px" }}
-      >
-        {header}
-      </Typography>
+      <Box sx={{ textAlign: "center" }}>
+        <TypographyUnderlined
+          variant="h5"
+          gutterBottom
+          marked="center"
+          align="center"
+        >
+          {header}
+        </TypographyUnderlined>
+      </Box>
+
       <List sx={{ width: "100%", bgcolor: "background.paper" }}>
         {data.map((obj) => {
           return (

--- a/knowledge/components/typographyUnderlined.js
+++ b/knowledge/components/typographyUnderlined.js
@@ -1,0 +1,19 @@
+import Typography from "@mui/material/Typography";
+import { styled } from "@mui/material/styles";
+
+const TypographyUnderlined = styled(Typography)(() => ({
+  display: "inline-block",
+  paddingBottom: "5px",
+  position: "relative",
+  "&::before": {
+    content: '""',
+    position: "absolute",
+    width: "50%",
+    height: "1px",
+    bottom: "0",
+    left: "25%",
+    borderBottom: "1px solid #ff8a33 ",
+  },
+}));
+
+export default TypographyUnderlined;


### PR DESCRIPTION
This PR adds a new component that has a line below the text. 
It is being used in the title of the linked node list.
<img width="448" alt="Screen Shot 2022-05-17 at 19 15 21" src="https://user-images.githubusercontent.com/1402054/168932288-90cf3953-ab6b-4f8f-b35d-8d4732ac6d24.png">


<img width="164" alt="Screen Shot 2022-05-17 at 19 15 12" src="https://user-images.githubusercontent.com/1402054/168932300-aadfd621-e2f1-4136-bacb-9b532a954c89.png">

