### PR TITLE
Bug/208 remove margin right of the share icon on single node page

### DIFF
--- a/knowledge/components/AppFooter.tsx
+++ b/knowledge/components/AppFooter.tsx
@@ -156,7 +156,7 @@ export default function AppFooter() {
                 textDecorationColor: theme => theme.palette.common.white
               }}
             >
-              <GitHubIcon />
+              <GitHubIcon fontSize="inherit" />
             </Link>
             <Typography color={theme => theme.palette.common.white} sx={{ display: { xs: "none", md: "block" } }}>
               We're committed to OpenSource on{" "}
@@ -171,7 +171,7 @@ export default function AppFooter() {
               >
                 Github
               </Link>{" "}
-              <GitHubIcon />
+              <GitHubIcon fontSize="inherit" />
             </Typography>
             <Typography color={theme => theme.palette.grey[500]}>{`©  1Cademy ${new Date().getFullYear()}`}</Typography>
           </Box>

--- a/knowledge/components/NodeItemFull.tsx
+++ b/knowledge/components/NodeItemFull.tsx
@@ -86,6 +86,7 @@ export const NodeItemFull: FC<Props> = ({ node, contributors, references, tags }
             display: "flex",
             alignItems: "center",
             flexDirection: { xs: "column", sm: "row" },
+            flexWrap: "wrap",
             justifyContent: "space-between",
             mt: 5
           }}
@@ -111,10 +112,14 @@ export const NodeItemFull: FC<Props> = ({ node, contributors, references, tags }
 
             <Box sx={{ display: "flex" }}>
               <Button
-                sx={{ color: theme => (showShareButtons ? theme.palette.common.orange : theme.palette.grey[600]) }}
                 onClick={() => setShowShareButtons(!showShareButtons)}
+                sx={{
+                  minWidth: "20px",
+                  justifyContent: "start",
+                  color: theme => (showShareButtons ? theme.palette.common.orange : theme.palette.grey[600])
+                }}
               >
-                <ReplyIcon sx={{ mx: "12px", transform: "scale(-1,1)" }} />
+                <ReplyIcon sx={{ ml: "10px", transform: "scale(-1,1)" }} />
                 {!showShareButtons && <Typography py="2px">Share</Typography>}
               </Button>
               {showShareButtons && <ShareButtons />}


### PR DESCRIPTION
## Description

remove right margin of share icon and adjust upvotes icon when share buttons grow

Ref #208

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run npm run build to check the changes generate no new eslint warnings/errors?