### PR TITLE
Leaderboard visibility fixed

### DIFF
--- a/expHome/src/Components/ProjectManagement/Activities/Activities.js
+++ b/expHome/src/Components/ProjectManagement/Activities/Activities.js
@@ -327,7 +327,7 @@ const Activities = (props) => {
           {
             isAdmin
               ? (
-                  (activePage !== "Intellectual") 
+                  (activePage !== "Intellectual" &&  activePage !== "Experiments") 
                     ?  LBoard : null
                 )
               : LBoard

--- a/expHome/src/Components/ProjectManagement/Activities/Activities.js
+++ b/expHome/src/Components/ProjectManagement/Activities/Activities.js
@@ -294,6 +294,27 @@ const Activities = (props) => {
     );
   }
 
+  const LBoard = (
+    <div className="Columns40_60">
+      <Alert severity="warning">
+        <ProjectPoints projectPoints={projectPoints} />
+        <Button
+          onClick={expandLeaderboard}
+          className={expanded ? "Button Red" : "Button Green"}
+          variant="contained"
+        >
+          {expanded ? "Collapse" : "Expand"} leaderboard details
+        </Button>
+      </Alert>
+      <LeaderBoard
+        fullname={fullname}
+        expanded={expanded}
+        researchers={researchers}
+        isResearcherCriteriaMet={isResearcherCriteriaMet}
+        makeResearcherChipContent={makeResearcherChipContent}
+      />
+    </div>
+  );
   return (
     <div id="ActivitiesContainer">
       {notAResearcher ? (
@@ -302,28 +323,16 @@ const Activities = (props) => {
           {projects.length > 0 ? `the project ${project}!` : "any project!"}
         </h1>
       ) : (
-        activePage !== "Intellectual" ||
-        (!isAdmin && (
-          <div className="Columns40_60">
-            <Alert severity="warning">
-              <ProjectPoints projectPoints={projectPoints} />
-              <Button
-                onClick={expandLeaderboard}
-                className={expanded ? "Button Red" : "Button Green"}
-                variant="contained"
-              >
-                {expanded ? "Collapse" : "Expand"} leaderboard details
-              </Button>
-            </Alert>
-            <LeaderBoard
-              fullname={fullname}
-              expanded={expanded}
-              researchers={researchers}
-              isResearcherCriteriaMet={isResearcherCriteriaMet}
-              makeResearcherChipContent={makeResearcherChipContent}
-            />
-          </div>
-        ))
+        <>
+          {
+            isAdmin
+              ? (
+                  (activePage !== "Intellectual" &&  activePage !== "Experiments") 
+                    ?  LBoard : null
+                )
+              : LBoard
+          }
+        </>
       )}
       {currentPage}
     </div>

--- a/expHome/src/Components/ProjectManagement/Activities/Activities.js
+++ b/expHome/src/Components/ProjectManagement/Activities/Activities.js
@@ -327,7 +327,7 @@ const Activities = (props) => {
           {
             isAdmin
               ? (
-                  (activePage !== "Intellectual" &&  activePage !== "Experiments") 
+                  (activePage !== "Intellectual") 
                     ?  LBoard : null
                 )
               : LBoard


### PR DESCRIPTION
if a researcher is admin, only show the leaderboard on 1Cademy, instructors, and freeRecallGrades
if a researcher is not admin, show leaderboard on all pages.