### PR TITLE
fix the issue with the tabs in the home page not showing the underline  when you click on a tab 

### DIFF
--- a/expHome/src/Components/Home/modules/views/AppAppBar.js
+++ b/expHome/src/Components/Home/modules/views/AppAppBar.js
@@ -207,7 +207,7 @@ const AppAppBar = (props) => {
             </Box>
           </Tooltip>
           <Tabs
-            value={1}
+            value={props.section}
             variant="scrollable"
             scrollButtons="auto"
             allowScrollButtonsMobile


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/62210295/177054181-f6952577-19fc-4802-8d13-1edf745030be.png)

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
