### PR TITLE
Remove the unnecessary  500 response from the bulkGradeFreeRecall function

### DIFF
--- a/expHome/functions/projectManagement.js
+++ b/expHome/functions/projectManagement.js
@@ -441,7 +441,6 @@ exports.bulkGradeFreeRecall = async (req, res) => {
         return res.status(500).json({ errMsg: err.message, success: false });
       });
   }
-  return res.status(500).json({ errMsg: 'some parameters missing', success: false });
 };
 
 exports.voteEndpoint = async (req, res) => {


### PR DESCRIPTION


## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
