### PR TITLE
change the  limit  number of documents retreived from the recallGrades

### DIFF
--- a/expHome/functions/projectManagement.js
+++ b/expHome/functions/projectManagement.js
@@ -432,6 +432,7 @@ exports.bulkGradeFreeRecall = async (req, res) => {
       }
     })
       .then(() => {
+     
         return res
           .status(200)
           .json({ success: true, endpoint: "Bulk Upload", successData: req.body.phrasesWithGrades });
@@ -440,7 +441,10 @@ exports.bulkGradeFreeRecall = async (req, res) => {
         console.log({ err });
         return res.status(500).json({ errMsg: err.message, success: false });
       });
+  }else{
+    return res.status(500).json({ errMsg: 'some parameters missing', success: false });
   }
+
 };
 
 exports.voteEndpoint = async (req, res) => {

--- a/expHome/functions/projectManagement.js
+++ b/expHome/functions/projectManagement.js
@@ -441,7 +441,6 @@ exports.bulkGradeFreeRecall = async (req, res) => {
         return res.status(500).json({ errMsg: err.message, success: false });
       });
   }
-  return res.status(500).json({ errMsg: 'some parameters missing', success: false });
 };
 
 exports.voteEndpoint = async (req, res) => {

--- a/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
+++ b/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
@@ -53,6 +53,15 @@ const FreeRecallGrading = props => {
   const [snackbarMessage, setSnackbarMessage] = useState("");
   const [firstFiveRecallGrades, setFirstFiveRecallGrades] = useState([]);
   const [retrieveNext, setRetrieveNext] = useState(0);
+  const [limit, setLimit] = useState(1000);
+  
+
+  useEffect(()=>{
+    if((firstFiveRecallGrades.length === 0)&&(limit<=1000)){
+      setLimit(4000)
+ }
+  },[firstFiveRecallGrades,limit])
+
   // Retrieve a free-recall response that is not evaluated by four
   // researchers yet.
   useEffect(() => {
@@ -76,7 +85,7 @@ const FreeRecallGrading = props => {
         .orderBy("passage")
         .orderBy("user")
         .orderBy("session")
-        .limit(4000)
+        .limit(limit)
         .get();
 
       if (recallGradeDocs.docs.length === 0) {
@@ -108,6 +117,7 @@ const FreeRecallGrading = props => {
             (firstFve.length === 5 || recallGradeData.response !== firstFve[0].data.response)
           ) {
             setFirstFiveRecallGrades(firstFve);
+
             const passageDoc = await firebase.db.collection("passages").doc(firstFve[0].data.passage).get();
             setPassageData(passageDoc.data());
             break;
@@ -128,7 +138,7 @@ const FreeRecallGrading = props => {
     return () => retrieveFreeRecallResponse();
     // Every time the value of retrieveNext changes, retrieveFreeRecallResponse
     // should be called regardless of its value.
-  }, [firebase, fullname, notAResearcher, project, retrieveNext]);
+  }, [firebase, fullname, notAResearcher, project, retrieveNext,limit]);
 
   // Clicking the Yes or No buttons would trigger this function. grade can be
   // either true, meaning the researcher responded Yes, or false if they

--- a/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
+++ b/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
@@ -181,7 +181,7 @@ const FreeRecallGrading = props => {
 
   return (
   (firstFiveRecallGrades.length === 0)?
-  ( <Alert severity="info" size="larg">
+  ( <Alert severity="info" size="large">
      <AlertTitle>Info</AlertTitle>
     Since the recall grades is done collaboratively, you should wait for a few days so that other researchers grade the recalls you've graded before .
   </Alert>):  

--- a/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
+++ b/expHome/src/Components/ProjectManagement/FreeRecallGrading/FreeRecallGrading.js
@@ -5,6 +5,7 @@ import axios from "axios";
 
 import Box from "@mui/material/Box";
 import Alert from "@mui/material/Alert";
+import AlertTitle from '@mui/material/AlertTitle';
 import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -75,7 +76,7 @@ const FreeRecallGrading = props => {
         .orderBy("passage")
         .orderBy("user")
         .orderBy("session")
-        .limit(1000)
+        .limit(4000)
         .get();
 
       if (recallGradeDocs.docs.length === 0) {
@@ -85,7 +86,7 @@ const FreeRecallGrading = props => {
 
       for (let recallGradeDoc of recallGradeDocs.docs) {
         const recallGradeData = recallGradeDoc.data();
-
+       
         if (
           recallGradeData.user !== fullname &&
           (recallGradeData.researchersNum === 0 ||
@@ -114,7 +115,7 @@ const FreeRecallGrading = props => {
           firstFve.push({ data: recallGradeData, grade: false });
         }
       }
-      setSubmitting(false);
+      setSubmitting(false); 
       // ASA we find five free-recall phrases for a particular response
       // we set this flag to true to stop searching.
       return null;
@@ -177,7 +178,13 @@ const FreeRecallGrading = props => {
     setFirstFiveRecallGrades(grades);
   };
 
+
   return (
+  (firstFiveRecallGrades.length === 0)?
+  ( <Alert severity="info" size="larg">
+     <AlertTitle>Info</AlertTitle>
+    Since the recall grades is done collaboratively, you should wait for a few days so that other researchers grade the recalls you've graded before .
+  </Alert>):  
     <div id="FreeRecallGrading">
       <Alert severity="success">
         <ul>


### PR DESCRIPTION
## Description
change the  limit number of documents retreived from the recallGrades collection to 4000 and add an alert message if reserchers hdosn't get response also change how we are sending a failed response to the client in ProjectManagement cloud function

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
