### PR TITLE
Session Formatter's spacing between session number and day fixed.

### DIFF
--- a/expHome/src/Components/SchedulePage/sessionFormatter.js
+++ b/expHome/src/Components/SchedulePage/sessionFormatter.js
@@ -1,5 +1,6 @@
 const sessionFormatter = (start, minutes) => {
   return (
+    " " +
     start.toLocaleDateString(navigator.language, {
       weekday: "long",
       year: "numeric",


### PR DESCRIPTION
## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you run `npm run build:dev` to check the changes generate no new eslint warnings/errors?
