### PR TITLE
After removing the experiment participation requirement from the 1Cademy application process, the PubSub does not send reminder emails to community leaders for reviewing applications anymore.

### DIFF
--- a/expHome/functions/users.js
+++ b/expHome/functions/users.js
@@ -1283,7 +1283,7 @@ exports.applicationReminder = async context => {
     // postpones sending the next email until the next waitTime.
     let waitTime = 0;
     // Retrieve all the applicants who have completed the 3 experiment sessions.
-    const usersDocs = await db.collection("users").where("projectDone", "==", true).get();
+    const usersDocs = await db.collection("users").get();
     // Array of information to be emailed to every applicant whose application
     // is incomplete.
     const reminders = [];


### PR DESCRIPTION


## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you run `npm run build:dev` to check the changes generate no new eslint warnings/errors?
