### PR TITLE
For researchers, the experiment button in the drop-down menu under the user avatar in the navbar on the homepage, should direct them to /Activites/ not /Activites/experiment. It should only direct non-researcher users to /Activites/experiment

### DIFF
--- a/expHome/src/Components/Home/modules/views/AppAppBar.js
+++ b/expHome/src/Components/Home/modules/views/AppAppBar.js
@@ -166,7 +166,11 @@ const AppAppBar = (props) => {
     navigateTo("/");
   };
   const navigateToExperiment = () => {
-    navigateTo("Activities/Experiment");
+    if (!notAResearcher) {
+      navigateTo("Activities/");
+    } else {
+      navigateTo("Activities/experiment");
+    }
   };
   const toggleColorMode = (event) => {
     setColorMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
@@ -197,11 +201,11 @@ const AppAppBar = (props) => {
       )}
       {fullname && email && (
         <>
-          {!notAResearcher && (
+          {
             <MenuItem sx={{ flexGrow: 3 }} onClick={navigateToExperiment}>
               <BiotechIcon /> <span id="ExperimentActivities">Experiment Activities</span>
             </MenuItem>
-          )}
+          }
         <MenuItem sx={{ flexGrow: 3 }} onClick={signOut}>
           <LogoutIcon /> <span id="LogoutText">Logout</span>
         </MenuItem>


### PR DESCRIPTION
For researchers, the experiment button in the drop-down menu under the user avatar in the navbar on the homepage, should direct them to /Activites/ not /Activites/experiment. It should only direct non-researcher users to /Activites/experiment. #559

#559 

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you run `npm run build:dev` to check the changes generate no new eslint warnings/errors?
