### PR TITLE
Because we changed the data structure of onecademy it shows all the researchers' points in all the projects as 0

### DIFF
--- a/expHome/src/Components/RouterNav/RouterNav.js
+++ b/expHome/src/Components/RouterNav/RouterNav.js
@@ -345,7 +345,7 @@ const RouterNav = props => {
       const nodeTypesInterval = setInterval(() => {
         nodeType = nodeTypes[nodeTypeIdx];
         const { versionsColl } = getTypedCollections(firebaseOne.db, nodeType);
-        const versionsQuery = versionsColl.where("tags", "array-contains", projectSpecs.deTag);
+        const versionsQuery = versionsColl.where("tagIds", "array-contains", projectSpecs.deTag.node);
         versionsSnapshots.push(
           versionsQuery.onSnapshot(snapshot => {
             const docChanges = snapshot.docChanges();


### PR DESCRIPTION

https://github.com/ImanYZ/VisualExp/issues/566
#566 566

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you run `npm run build:dev` to check the changes generate no new eslint warnings/errors?
