### PR TITLE
feedback code page fixed when codeIds are empty

### DIFF
--- a/expHome/functions/projectManagement.js
+++ b/expHome/functions/projectManagement.js
@@ -2618,8 +2618,8 @@ exports.createTemporaryFeedbacodeCollection = async (req, res) => {
 
       // const feedbackRef = db.collection("feedbackCodeOrderV2").doc(project.trim());
       const feedbackCodeOrders = await db.collection("feedbackCodeOrderV2")
-        .where("project", project.trim())
-        .where("researcher", fullname)
+        .where("project", "==", project.trim())
+        .where("researcher", "==", fullname)
         .get();
       const feedbackCodeOrderRef = db.collection("feedbackCodeOrderV2").doc(
         feedbackCodeOrders.docs.length ? feedbackCodeOrders.docs[0].id : undefined
@@ -2661,6 +2661,6 @@ exports.createTemporaryFeedbacodeCollection = async (req, res) => {
       await batch.commit();
     }
   } catch (error) {
-    console.log({ error });
+    console.log({ error }, "error----------");
   }
 };

--- a/expHome/src/Components/ProjectManagement/CodeFeedback/CodeFeedback.js
+++ b/expHome/src/Components/ProjectManagement/CodeFeedback/CodeFeedback.js
@@ -437,8 +437,9 @@ const CodeFeedback = props => {
         .where("project", "==", project)
         .get();
       const orderData = feedbackCodesOrderDocs.docs.length ? feedbackCodesOrderDocs.docs[0].data() : {};
-      if (orderData?.codeIds && orderData?.codeIds.length === 0) {
+      if (orderData?.codeIds && !orderData?.codeIds.length) {
         setAllResponsesGraded(true);
+        return;
       } else {
         setAllResponsesGraded(false);
       }
@@ -1074,7 +1075,7 @@ const CodeFeedback = props => {
     setChoiceConditions(feedbackData.codersChoiceConditions[fullname]);
     setSubmitting(false);
   };
-  if (!choiceConditions[selectedSentence]) return null;
+  if (!choiceConditions[selectedSentence] && sentences.length) return null;
   return (
     <>
       {unApprovedCodes.length > 0 && (
@@ -1140,7 +1141,7 @@ const CodeFeedback = props => {
           </Alert>
         </div>
       )} */}
-      {sentences.length !== 0 ? (
+      {sentences.length ? (
         <>
           <Alert severity="warning" sx={{ mt: "15px", mb: "15px" }}>
             <h2>


### PR DESCRIPTION
## Description

feedback code page fixed when codeIds are empty

Ref #709
## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you run `npm run build:dev` to check the changes generate no new eslint warnings/errors?
